### PR TITLE
Fix / Merge upstream changes from CE 1.9.2.0 to Mage_Core_Block_Abstract

### DIFF
--- a/Mage/Core/Block/Abstract.php
+++ b/Mage/Core/Block/Abstract.php
@@ -1506,6 +1506,16 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         return $tags;
     }
 
+    /**
+     * Checks is request Url is secure
+     *
+     * @return bool
+     */
+    protected function _isSecure()
+    {
+        return $this->_getApp()->getFrontController()->getRequest()->isSecure();
+    }
+
     /*
      *  Changes to core methods (above):
      *   - toHtml


### PR DESCRIPTION
Method Mage_Core_Block_Abstract::_isSecure() was added in magento 1.9.2.0 (https://github.com/OpenMage/magento-mirror/commit/cb52550f2aa31026dfa9cb95709c567ebe3fded7#diff-5ad7a76de1099beed7788fd2c903f734).