### PR TITLE
Modernize module code and sync Mage/Core with latest OpenMage

### DIFF
--- a/Mage/Core/Block/Abstract.php
+++ b/Mage/Core/Block/Abstract.php
@@ -1,16 +1,10 @@
 <?php
+
 /**
- * OpenMage
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available at https://opensource.org/license/osl-3-0-php
- *
- * @category   Mage
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
  * @package    Mage_Core
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2019-2022 The OpenMage Contributors (https://www.openmage.org)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 /**
@@ -19,7 +13,6 @@
  * For block generation you must define Data source class, data source class method,
  * parameters array and block template
  *
- * @category   Mage
  * @package    Mage_Core
  *
  * @method $this setAdditionalHtml(string $value)
@@ -46,6 +39,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * Prefix for cache key
      */
     public const CACHE_KEY_PREFIX = 'BLOCK_';
+
     /**
      * Cache group Tag
      */
@@ -78,7 +72,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     protected $_parent;
 
     /**
-     * Short alias of this block that was refered from parent
+     * Short alias of this block that was referred from parent
      *
      * @var string
      */
@@ -169,6 +163,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * @var Varien_Object
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private static $_transportObject;
 
     /**
@@ -194,17 +189,17 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
 
     /**
      * Initialize factory instance
-     *
-     * @param array $args
      */
     public function __construct(array $args = [])
     {
         if (!empty($args['core_factory']) && ($args['core_factory'] instanceof Mage_Core_Model_Factory)) {
             $this->_factory = $args['core_factory'];
         }
+
         if (!empty($args['app']) && ($args['app'] instanceof Mage_Core_Model_App)) {
             $this->_app = $args['app'];
         }
+
         parent::__construct($args);
     }
 
@@ -255,6 +250,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         } else {
             throw new Exception(Mage::helper('core')->__("Can't retrieve request object"));
         }
+
         return $this->_request;
     }
 
@@ -271,7 +267,6 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Set parent block
      *
-     * @param   Mage_Core_Block_Abstract $block
      * @return  $this
      */
     public function setParentBlock(Mage_Core_Block_Abstract $block)
@@ -293,7 +288,6 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Set layout object
      *
-     * @param   Mage_Core_Model_Layout $layout
      * @return  $this
      */
     public function setLayout(Mage_Core_Model_Layout $layout)
@@ -344,7 +338,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     public function setIsAnonymous($flag)
     {
-        $this->_isAnonymous = (bool)$flag;
+        $this->_isAnonymous = (bool) $flag;
         return $this;
     }
 
@@ -404,6 +398,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             $this->getLayout()->unsetBlock($this->_nameInLayout)
                 ->setBlock($name, $this);
         }
+
         $this->_nameInLayout = $name;
         return $this;
     }
@@ -424,7 +419,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      *
      * Wrapper for method "setData"
      *
-     * @param   string $name
+     * @param   array|string $name
      * @param   mixed $value
      * @return  $this
      */
@@ -445,6 +440,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (is_string($block)) {
             $block = $this->getLayout()->getBlock($block);
         }
+
         if (!$block) {
             return $this;
         }
@@ -454,6 +450,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             if (empty($suffix)) {
                 $suffix = 'child' . count($this->_children);
             }
+
             $blockName = $this->getNameInLayout() . '.' . $suffix;
 
             if ($this->getLayout()) {
@@ -517,12 +514,12 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     public function unsetCallChild($alias, $callback, $result, $params)
     {
+        $args = func_get_args();
         $child = $this->getChild($alias);
         if ($child) {
-            $args = func_get_args();
             $alias = array_shift($args);
             $callback = array_shift($args);
-            $result = (string)array_shift($args);
+            $result = (string) array_shift($args);
             if (!is_array($params)) {
                 $params = $args;
             }
@@ -532,6 +529,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 $this->unsetChild($alias);
             }
         }
+
         return $this;
     }
 
@@ -557,9 +555,11 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     {
         if ($name === '') {
             return $this->_children;
+        } elseif (isset($this->_children[$name])) {
+            return $this->_children[$name];
         }
 
-        return $this->_children[$name] ?? false;
+        return false;
     }
 
     /**
@@ -581,10 +581,12 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             } else {
                 $children = $this->getChild();
             }
+
             $out = '';
             foreach ($children as $child) {
                 $out .= $this->_getChildHtml($child->getBlockAlias(), $useCache);
             }
+
             return $out;
         } else {
             return $this->_getChildHtml($name, $useCache);
@@ -603,10 +605,12 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (empty($name)) {
             return '';
         }
+
         $child = $this->getChild($name);
         if (!$child) {
             return '';
         }
+
         return $child->getChildHtml($childName, $useCache, $sorted);
     }
 
@@ -621,6 +625,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         foreach ($this->getSortedChildren() as $childName) {
             $children[$childName] = $this->getLayout()->getBlock($childName);
         }
+
         return $children;
     }
 
@@ -656,9 +661,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * @param   string $name
      * @param   Mage_Core_Block_Abstract $child
      */
-    protected function _beforeChildToHtml($name, $child)
-    {
-    }
+    protected function _beforeChildToHtml($name, $child) {}
 
     /**
      * Retrieve block html
@@ -671,9 +674,11 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (!($layout = $this->getLayout()) && !($layout = $this->getAction()->getLayout())) {
             return '';
         }
+
         if (!($block = $layout->getBlock($name))) {
             return '';
         }
+
         return $block->toHtml();
     }
 
@@ -691,6 +696,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (is_string($block)) {
             $block = $this->getLayout()->getBlock($block);
         }
+
         if (!$block) {
             /*
              * if we don't have block - don't throw exception because
@@ -700,6 +706,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             // ->__('Invalid block name to set child %s: %s', $alias, $block));
             return $this;
         }
+
         if ($block->getIsAnonymous()) {
             $this->setChild('', $block);
             $name = $block->getNameInLayout();
@@ -728,16 +735,15 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 if ($after) {
                     $key++;
                 }
+
                 array_splice($this->_sortedChildren, $key, 0, $name);
+            } elseif ($after) {
+                $this->_sortedChildren[] = $name;
             } else {
-                if ($after) {
-                    $this->_sortedChildren[] = $name;
-                } else {
-                    array_unshift($this->_sortedChildren, $name);
-                }
+                array_unshift($this->_sortedChildren, $name);
             }
 
-            $this->_sortInstructions[$name] = [$siblingName, (bool)$after, $key !== false];
+            $this->_sortInstructions[$name] = [$siblingName, (bool) $after, $key !== false];
         }
 
         return $this;
@@ -752,10 +758,11 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     public function sortChildren($force = false)
     {
         foreach ($this->_sortInstructions as $name => $list) {
-            list($siblingName, $after, $exists) = $list;
+            [$siblingName, $after, $exists] = $list;
             if ($exists && !$force) {
                 continue;
             }
+
             $this->_sortInstructions[$name][2] = true;
 
             $index = array_search($name, $this->_sortedChildren);
@@ -770,6 +777,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 if ($index == $siblingKey + 1) {
                     continue;
                 }
+
                 // remove sibling from array
                 array_splice($this->_sortedChildren, $index, 1, []);
                 // insert sibling after
@@ -779,6 +787,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 if ($index == $siblingKey - 1) {
                     continue;
                 }
+
                 // remove sibling from array
                 array_splice($this->_sortedChildren, $index, 1, []);
                 // insert sibling after
@@ -806,13 +815,13 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * Make sure specified block will be registered in the specified child groups
      *
      * @param string $groupName
-     * @param Mage_Core_Block_Abstract $child
      */
     public function addToChildGroup($groupName, Mage_Core_Block_Abstract $child)
     {
         if (!isset($this->_childGroups[$groupName])) {
             $this->_childGroups[$groupName] = [];
         }
+
         if (!in_array($child->getBlockAlias(), $this->_childGroups[$groupName])) {
             $this->_childGroups[$groupName][] = $child->getBlockAlias();
         }
@@ -848,6 +857,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (!isset($this->_childGroups[$groupName])) {
             return $result;
         }
+
         foreach ($this->getSortedChildBlocks() as $block) {
             $alias = $block->getBlockAlias();
             if (in_array($alias, $this->_childGroups[$groupName])) {
@@ -862,6 +872,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 }
             }
         }
+
         return $result;
     }
 
@@ -870,7 +881,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      *
      * @param string $alias
      * @param string $key
-     * @return mixed
+     * @return mixed|void
      */
     public function getChildData($alias, $key = '')
     {
@@ -905,6 +916,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         } else {
             $this->_frameCloseTag = '/' . $openTag;
         }
+
         return $this;
     }
 
@@ -949,6 +961,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 $translate->setTranslateInline(true);
             }
         }
+
         $html = $this->_afterToHtml($html);
 
         /**
@@ -964,14 +977,14 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (self::$_transportObject === null) {
             self::$_transportObject = new Varien_Object();
         }
+
         self::$_transportObject->setHtml($html);
         Mage::dispatchEvent(
             'core_block_abstract_to_html_after',
-            ['block' => $this, 'transport' => self::$_transportObject]
+            ['block' => $this, 'transport' => self::$_transportObject],
         );
-        $html = self::$_transportObject->getHtml();
 
-        return $html;
+        return self::$_transportObject->getHtml();
     }
 
     /**
@@ -1012,7 +1025,9 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     protected function _getUrlModel()
     {
-        return Mage::getModel($this->_getUrlModelClass());
+        /** @var Mage_Core_Model_Url $model */
+        $model = Mage::getModel($this->_getUrlModelClass());
+        return $model;
     }
 
     /**
@@ -1040,6 +1055,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (!Mage::helper('adminhtml')->isEnabledSecurityKeyUrl()) {
             $params[Mage_Core_Model_Url::FORM_KEY] = $this->getFormKey();
         }
+
         return $this->getUrl($route, $params);
     }
 
@@ -1071,7 +1087,6 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * Retrieve url of skins file
      *
      * @param   string $file path to file in skin
-     * @param   array $params
      * @return  string
      */
     public function getSkinUrl($file = null, array $params = [])
@@ -1089,13 +1104,13 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (is_null($this->_messagesBlock)) {
             return $this->getLayout()->getMessagesBlock();
         }
+
         return $this->_messagesBlock;
     }
 
     /**
      * Set messages block
      *
-     * @param   Mage_Core_Block_Messages $block
      * @return  $this
      */
     public function setMessagesBlock(Mage_Core_Block_Messages $block)
@@ -1108,7 +1123,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * Return block helper
      *
      * @param string $type
-     * @return $this
+     * @return Mage_Core_Block_Abstract
      */
     public function getHelper($type)
     {
@@ -1126,29 +1141,29 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if ($this->getLayout()) {
             return $this->getLayout()->helper($name);
         }
+
         return Mage::helper($name);
     }
 
     /**
      * Retrieve formatting date
      *
-     * @param   string $date
-     * @param   string $format
-     * @param   bool $showTime
-     * @param   bool $useTimezone
-     * @return  string
+     * @param string|int|Zend_Date|null $date
+     * @param string $format
+     * @param bool $showTime
+     * @return string
      */
-    public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false, $useTimezone = true)
+    public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false)
     {
         /** @var Mage_Core_Helper_Data $helper */
         $helper = $this->helper('core');
-        return $helper->formatDate($date, $format, $showTime, $useTimezone);
+        return $helper->formatDate($date, $format, $showTime);
     }
 
     /**
      * Retrieve formatting timezone date
      *
-     * @param null|int|string|Zend_Date $date
+     * @param string|int|Zend_Date|null $date
      */
     public function formatTimezoneDate(
         $date = null,
@@ -1185,10 +1200,11 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     {
         $module = $this->getData('module_name');
         if (is_null($module)) {
-            $class = get_class($this);
+            $class = static::class;
             $module = substr($class, 0, strpos($class, '_Block'));
             $this->setData('module_name', $module);
         }
+
         return $module;
     }
 
@@ -1196,6 +1212,9 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * Translate block sentence
      *
      * @return string
+     *
+     * @SuppressWarnings("PHPMD.CamelCaseMethodName")
+     * @SuppressWarnings("PHPMD.ShortMethodName")
      */
     public function __()
     {
@@ -1220,9 +1239,9 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Escape html entities
      *
-     * @param   string|array $data
-     * @param   array $allowedTags
-     * @return  string
+     * @param string|string[] $data
+     * @param array|null $allowedTags
+     * @return null|string|string[]
      */
     public function escapeHtml($data, $allowedTags = null)
     {
@@ -1232,7 +1251,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Wrapper for escapeHtml() function with keeping original value
      *
-     * @param null|array $allowedTags
+     * @param string[]|null $allowedTags
      *
      * @see Mage_Core_Model_Security_HtmlEscapedString::getUnescapedValue()
      */
@@ -1244,8 +1263,8 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Wrapper for escapeHtml() function with keeping original value
      *
-     * @param  array                                        $data
-     * @param  null|array                                   $allowedTags
+     * @param string[] $data
+     * @param string[]|null $allowedTags
      * @return Mage_Core_Model_Security_HtmlEscapedString[]
      *
      *  @see Mage_Core_Model_Security_HtmlEscapedString::getUnescapedValue()
@@ -1315,7 +1334,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * @param string $quote
      * @return mixed
      */
-    public function jsQuoteEscape($data, $quote = '\'')
+    public function jsQuoteEscape($data, $quote = "'")
     {
         return $this->helper('core')->jsQuoteEscape($data, $quote);
     }
@@ -1349,6 +1368,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if ($this->_getApp()->useCache(self::CACHE_GROUP)) {
             $this->_getApp()->setUseSessionVar(true);
         }
+
         return $this;
     }
 
@@ -1368,6 +1388,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             $html = $model->sessionUrlVar($html);
             Varien_Profiler::stop('CACHE_URL');
         }
+
         return $html;
     }
 
@@ -1380,7 +1401,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     public function getCacheKeyInfo()
     {
         return [
-            $this->getNameInLayout()
+            $this->getNameInLayout(),
         ];
     }
 
@@ -1393,13 +1414,14 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     {
         if ($this->hasData('cache_key')) {
             $cacheKey = $this->getData('cache_key');
-            if (strpos($cacheKey, self::CACHE_KEY_PREFIX) !== 0) {
+            if (!str_starts_with($cacheKey, self::CACHE_KEY_PREFIX)) {
                 $cacheKey = self::CACHE_KEY_PREFIX . $cacheKey;
                 $this->setData('cache_key', $cacheKey);
             }
 
             return $cacheKey;
         }
+
         /**
          * don't prevent recalculation by saving generated cache key
          * because of ability to render single block instance with different data
@@ -1408,8 +1430,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         //ksort($key);  // ignore order
         $key = array_values($key); // ignore array keys
         $key = implode('|', $key);
-        $key = sha1($key);
-        return $key;
+        return sha1($key);
     }
 
     /**
@@ -1423,12 +1444,14 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if ($tagsCache) {
             $tags = json_decode($tagsCache);
         }
+
         if (!isset($tags) || !is_array($tags) || empty($tags)) {
             $tags = !$this->hasData(self::CACHE_TAGS_DATA_KEY) ? [] : $this->getData(self::CACHE_TAGS_DATA_KEY);
             if (!in_array(self::CACHE_GROUP, $tags)) {
                 $tags[] = self::CACHE_GROUP;
             }
         }
+
         return array_unique($tags);
     }
 
@@ -1450,7 +1473,6 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Add tags from specified model to current block
      *
-     * @param Mage_Core_Model_Abstract $model
      * @return $this
      */
     public function addModelTags(Mage_Core_Model_Abstract $model)
@@ -1459,11 +1481,12 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if ($cacheTags !== false) {
             $this->addCacheTag($cacheTags);
         }
+
         return $this;
     }
 
     /**
-     * Get block cache life time
+     * Get block cache lifetime
      *
      * @return int|null
      */
@@ -1472,6 +1495,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (!$this->hasData('cache_lifetime')) {
             return null;
         }
+
         return $this->getData('cache_lifetime');
     }
 
@@ -1495,6 +1519,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (is_null($this->getCacheLifetime()) || !$this->_getApp()->useCache(self::CACHE_GROUP)) {
             return false;
         }
+
         $cacheKey = $this->getCacheKey();
         /** @var Mage_Core_Model_Session $session */
         $session = Mage::getSingleton('core/session');
@@ -1503,9 +1528,8 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             $cacheData = str_replace(
                 $this->_getSidPlaceholder($cacheKey),
                 $session->getSessionIdQueryParam() . '=' . $session->getEncryptedSessionId(),
-                $cacheData
+                $cacheData,
             );
-
             /* START: Changed by Cm_Diehard */
             // If cache load is successful, add cache record tags to diehard tags
             if (Mage::helper('diehard')->getLifetime()) {
@@ -1516,6 +1540,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             }
             /* END: Changed by Cm_Diehard */
         }
+
         return $cacheData;
     }
 
@@ -1539,13 +1564,14 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if (is_null($this->getCacheLifetime()) || !$this->_getApp()->useCache(self::CACHE_GROUP)) {
             return false;
         }
+
         $cacheKey = $this->getCacheKey();
         /** @var Mage_Core_Model_Session $session */
         $session = Mage::getSingleton('core/session');
         $data = str_replace(
             $session->getSessionIdQueryParam() . '=' . $session->getEncryptedSessionId(),
             $this->_getSidPlaceholder($cacheKey),
-            $data
+            $data,
         );
 
         // Changed by Cm_Direhard $tags = $this->getCacheTags();
@@ -1555,7 +1581,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             json_encode($tags),
             $this->_getTagsCacheKey($cacheKey),
             $tags,
-            $this->getCacheLifetime()
+            $this->getCacheLifetime(),
         );
         return $this;
     }
@@ -1569,8 +1595,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     protected function _getTagsCacheKey($cacheKey = null)
     {
         $cacheKey = !empty($cacheKey) ? $cacheKey : $this->getCacheKey();
-        $cacheKey = md5($cacheKey . '_tags');
-        return $cacheKey;
+        return md5($cacheKey . '_tags');
     }
 
     /**
@@ -1590,7 +1615,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
 
     /**
      * Collect and retrieve items tags.
-     * Item should implements Mage_Core_Model_Abstract::getCacheIdTags method
+     * Item should implement Mage_Core_Model_Abstract::getCacheIdTags method
      *
      * @param array|Varien_Data_Collection $items
      * @return array
@@ -1604,8 +1629,10 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             if ($itemTags === false) {
                 continue;
             }
+
             $tags = array_merge($tags, $itemTags);
         }
+
         return $tags;
     }
 
@@ -1639,7 +1666,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
                 $selector = $this->getDiehardSelector();
                 $this->setFrameTags('span id="' . substr($selector,1) . '"', '/span');
             }
-            $helper = Mage::helper('diehard'); /* @var $helper Cm_Diehard_Helper_Data */
+            $helper = Mage::helper('diehard'); /** @var Cm_Diehard_Helper_Data $helper */
             $helper->addDynamicBlock($selector, $this->getNameInLayout());
         }
         // Specific rendering mode
@@ -1666,7 +1693,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     public function setDiehardCacheLifetime($lifetime = FALSE)
     {
-        $helper = Mage::helper('diehard'); /* @var $helper Cm_Diehard_Helper_Data */
+        $helper = Mage::helper('diehard'); /** @var Cm_Diehard_Helper_Data $helper */
         if ($helper->isEnabled() && $this->getRequest()->isGet()) {
             $helper->setLifetime($lifetime);
         }
@@ -1689,9 +1716,9 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     public function ignoreBlockUnless($args, $ignore = TRUE)
     {
         if (! is_array($args)) {
-            $args = array($args);
+            $args = [$args];
         }
-        $helper = Mage::helper('diehard'); /* @var $helper Cm_Diehard_Helper_Data */
+        $helper = Mage::helper('diehard'); /** @var Cm_Diehard_Helper_Data $helper */
         $ignoreBlock = $ignore;
         foreach ($args as $arg) {
             if (! strpos($arg, '::')) continue;
@@ -1746,7 +1773,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         }
         $method = preg_replace('/[^a-zA-Z0-9]+/', '_', $method);
         $helper = Mage::helper($helperName);
-        call_user_func_array(array($helper, $method), $args);
+        call_user_func_array([$helper, $method], $args);
     }
 
     /**
@@ -1754,7 +1781,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     public function addDefaultIgnored()
     {
-        $helper = Mage::helper('diehard'); /* @var $helper Cm_Diehard_Helper_Data */
+        $helper = Mage::helper('diehard'); /** @var Cm_Diehard_Helper_Data $helper */
         $helper->addDefaultIgnoredBlock($this);
     }
 
@@ -1787,7 +1814,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         }
         if ($model && $model instanceof Mage_Core_Model_Abstract && $model->getId()) {
             if ($tags = $model->getCacheIdTags()) {
-                $helper = Mage::helper('diehard'); /* @var $helper Cm_Diehard_Helper_Data */
+                $helper = Mage::helper('diehard'); /** @var Cm_Diehard_Helper_Data $helper */
                 $helper->addTags($tags);
             }
         }

--- a/Mage/Core/Block/Template.php
+++ b/Mage/Core/Block/Template.php
@@ -1,22 +1,15 @@
 <?php
+
 /**
- * OpenMage
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available at https://opensource.org/license/osl-3-0-php
- *
- * @category   Mage
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
  * @package    Mage_Core
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2015-2022 The OpenMage Contributors (https://www.openmage.org)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 /**
  * Base html block
  *
- * @category   Mage
  * @package    Mage_Core
  *
  * @method $this setContentHeading(string $value)
@@ -32,9 +25,13 @@
 class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
 {
     public const XML_PATH_DEBUG_TEMPLATE_HINTS_ADMIN        = 'dev/debug/template_hints_admin';
+
     public const XML_PATH_DEBUG_TEMPLATE_HINTS_BLOCKS_ADMIN = 'dev/debug/template_hints_blocks_admin';
+
     public const XML_PATH_DEBUG_TEMPLATE_HINTS              = 'dev/debug/template_hints';
+
     public const XML_PATH_DEBUG_TEMPLATE_HINTS_BLOCKS       = 'dev/debug/template_hints_blocks';
+
     public const XML_PATH_TEMPLATE_ALLOW_SYMLINK            = 'dev/template/allow_symlink';
 
     /**
@@ -56,20 +53,24 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
     protected $_jsUrl;
 
     protected static $_showTemplateHintsAdmin;
+
     protected static $_showTemplateHintsBlocksAdmin;
+
     protected static $_showTemplateHints;
+
     protected static $_showTemplateHintsBlocks;
 
     /**
      * Path to template file in theme.
      *
-     * @var string|null
+     * @var string
      */
-    protected $_template;
+    protected $_template = '';
 
     /**
      * Internal constructor, that is called from real constructor
      *
+     * @return void
      */
     protected function _construct()
     {
@@ -125,6 +126,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
         if ($area) {
             $params['_area'] = $area;
         }
+
         return Mage::getDesign()->getTemplateFilename($this->getTemplate(), $params);
     }
 
@@ -153,6 +155,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
         } else {
             $this->_viewVars[$key] = $value;
         }
+
         return $this;
     }
 
@@ -164,11 +167,12 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
      */
     public function setScriptPath($dir)
     {
-        if (strpos($dir, '..') === false && ($dir === Mage::getBaseDir('design') || strpos(realpath($dir), realpath(Mage::getBaseDir('design'))) === 0)) {
+        if (!str_contains($dir, '..') && ($dir === Mage::getBaseDir('design') || str_starts_with(realpath($dir), realpath(Mage::getBaseDir('design'))))) {
             $this->_viewDir = $dir;
         } else {
             Mage::log('Not valid script path:' . $dir, Zend_Log::CRIT, null, true);
         }
+
         return $this;
     }
 
@@ -182,6 +186,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
         if ($this->getLayout()) {
             return $this->getLayout()->getDirectOutput();
         }
+
         return false;
     }
 
@@ -196,6 +201,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
             self::$_showTemplateHintsBlocksAdmin = Mage::getStoreConfig(self::XML_PATH_DEBUG_TEMPLATE_HINTS_BLOCKS_ADMIN)
                 && Mage::helper('core')->isDevAllowed();
         }
+
         return self::$_showTemplateHintsAdmin;
     }
 
@@ -210,6 +216,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
             self::$_showTemplateHintsBlocks = Mage::getStoreConfig(self::XML_PATH_DEBUG_TEMPLATE_HINTS_BLOCKS)
                 && Mage::helper('core')->isDevAllowed();
         }
+
         return self::$_showTemplateHints;
     }
 
@@ -220,16 +227,16 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
     {
         if (!is_null($this->getCacheLifetime())) {
             return 'green';
-        }
+        } else {
+            $currentParentBlock = $this;
+            $i = 0;
+            while ($i++ < 20 && $currentParentBlock instanceof Mage_Core_Block_Abstract) {
+                if (!is_null($currentParentBlock->getCacheLifetime())) {
+                    return 'orange'; // not cached, but within cached
+                }
 
-        $currentParentBlock = $this;
-        $i = 0;
-        while ($i++ < 20 && $currentParentBlock instanceof Mage_Core_Block_Abstract) {
-            if (!is_null($currentParentBlock->getCacheLifetime())) {
-                return 'orange'; // not cached, but within cached
+                $currentParentBlock = $currentParentBlock->getParentBlock();
             }
-
-            $currentParentBlock = $currentParentBlock->getParentBlock();
         }
 
         return 'red';
@@ -255,43 +262,46 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
         if (!$do) {
             ob_start();
         }
+
         if ($hints) {
             $cacheHintStatusColor = $this->_getCacheHintStatusColor();
             echo <<<HTML
 <div style="position:relative; border:1px dotted {$cacheHintStatusColor}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
 <div style="position:absolute; left:0; top:0; padding:2px 5px; background:{$cacheHintStatusColor}; color:white; font:normal 11px Arial;
-text-align:left !important; z-index:998;" onmouseover="this.style.zIndex='999'"
+text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'"
 onmouseout="this.style.zIndex='998'" title="{$fileName}">{$fileName}</div>
 HTML;
             if (Mage::app()->getStore()->isAdmin() ? self::$_showTemplateHintsBlocksAdmin : self::$_showTemplateHintsBlocks) {
-                $thisClass = get_class($this);
+                $thisClass = static::class;
                 echo <<<HTML
 <div style="position:absolute; right:0; top:0; padding:2px 5px; background:{$cacheHintStatusColor}; color:blue; font:normal 11px Arial;
-text-align:left !important; z-index:998;" onmouseover="this.style.zIndex='999'" onmouseout="this.style.zIndex='998'"
+text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'" onmouseout="this.style.zIndex='998'"
 title="{$thisClass}">{$thisClass}</div>
 HTML;
             }
         }
 
         try {
-            if (strpos($this->_viewDir . DS . $fileName, '..') === false
+            if (!str_contains($this->_viewDir . DS . $fileName, '..')
                 &&
-                ($this->_viewDir == Mage::getBaseDir('design') || strpos(realpath($this->_viewDir), realpath(Mage::getBaseDir('design'))) === 0)
+                ($this->_viewDir == Mage::getBaseDir('design') || str_starts_with(realpath($this->_viewDir), realpath(Mage::getBaseDir('design'))))
             ) {
                 include $this->_viewDir . DS . $fileName;
             } else {
-                $thisClass = get_class($this);
+                $thisClass = static::class;
                 Mage::log('Not valid template file:' . $fileName . ' class: ' . $thisClass, Zend_Log::CRIT, null, true);
             }
-        } catch (Throwable $e) {
+        } catch (Throwable $throwable) {
             if (!$do) {
                 ob_get_clean();
                 $do = true;
             }
+
             if (Mage::getIsDeveloperMode()) {
-                throw $e;
+                throw $throwable;
             }
-            Mage::logException($e);
+
+            Mage::logException($throwable);
         }
 
         if ($hints) {
@@ -303,6 +313,7 @@ HTML;
         } else {
             $html = '';
         }
+
         Varien_Profiler::stop($fileName);
         return $html;
     }
@@ -328,6 +339,7 @@ HTML;
         if (!$this->getTemplate()) {
             return '';
         }
+
         return $this->renderView();
     }
 
@@ -341,6 +353,7 @@ HTML;
         if (!$this->_baseUrl) {
             $this->_baseUrl = Mage::getBaseUrl();
         }
+
         return $this->_baseUrl;
     }
 
@@ -357,19 +370,19 @@ HTML;
         if (!$this->_jsUrl) {
             $this->_jsUrl = Mage::getBaseUrl('js');
         }
+
         return $this->_jsUrl . $fileName;
     }
 
     /**
      * Get data from specified object
      *
-     * @param Varien_Object $object
      * @param string $key
      * @return mixed
      */
     public function getObjectData(Varien_Object $object, $key)
     {
-        return $object->getDataUsingMethod((string)$key);
+        return $object->getDataUsingMethod((string) $key);
     }
 
     /**
@@ -380,8 +393,8 @@ HTML;
         return [
             'BLOCK_TPL',
             Mage::app()->getStore()->getCode(),
-            $this->getTemplate() ? $this->getTemplateFile() : '',
-            'template' => $this->getTemplate()
+            $this->getTemplateFile(),
+            'template' => $this->getTemplate(),
         ];
     }
 

--- a/Mage/Core/Controller/Response/Http.php
+++ b/Mage/Core/Controller/Response/Http.php
@@ -1,22 +1,15 @@
 <?php
+
 /**
- * OpenMage
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available at https://opensource.org/license/osl-3-0-php
- *
- * @category   Mage
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
  * @package    Mage_Core
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2019-2022 The OpenMage Contributors (https://www.openmage.org)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 /**
  * Custom Zend_Controller_Response_Http class (formally)
  *
- * @category   Mage
  * @package    Mage_Core
  */
 class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
@@ -37,7 +30,7 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
         // START: Changed by Cm_Diehard
         // Only check if we can send headers if we have headers to send
         if (count($this->_headersRaw) || count($this->_headers) || (200 != $this->_httpResponseCode)) {
-            if ( ! $this->canSendHeaders()) {
+            if (!$this->canSendHeaders()) {
                 headers_sent($file, $line);
                 Mage::log("HEADERS ALREADY SENT: $file:$line");
                 return $this;
@@ -48,7 +41,7 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
         }
         // END: Changed by Cm_Diehard
 
-        if (substr(php_sapi_name(), 0, 3) == 'cgi') {
+        if (str_starts_with(PHP_SAPI, 'cgi')) {
             $statusSent = false;
             foreach ($this->_headersRaw as $i => $header) {
                 if (stripos($header, 'status:') === 0) {
@@ -59,6 +52,7 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
                     }
                 }
             }
+
             foreach ($this->_headers as $i => $header) {
                 if (strcasecmp($header['name'], 'status') === 0) {
                     if ($statusSent) {
@@ -95,11 +89,12 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
         if (self::$_transportObject === null) {
             self::$_transportObject = new Varien_Object();
         }
+
         self::$_transportObject->setUrl($url);
         self::$_transportObject->setCode($code);
         Mage::dispatchEvent(
             'controller_response_redirect',
-            ['response' => $this, 'transport' => self::$_transportObject]
+            ['response' => $this, 'transport' => self::$_transportObject],
         );
 
         return parent::setRedirect(self::$_transportObject->getUrl(), self::$_transportObject->getCode());
@@ -107,7 +102,8 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
 
     /**
      * Method send already collected headers and exit from script
-     * @return never
+     * @return void
+     * @SuppressWarnings("PHPMD.ExitExpression")
      */
     public function sendHeadersAndExit()
     {

--- a/code/Block/Beforebodyend.php
+++ b/code/Block/Beforebodyend.php
@@ -21,7 +21,7 @@ class Cm_Diehard_Block_Beforebodyend extends Mage_Core_Block_Template
      */
     public function getDynamicParamsCombined()
     {
-        $params = array();
+        $params = [];
         $params['full_action_name'] = $this->getAction()->getFullActionName();
         $params['blocks'] = $this->diehard()->getDynamicBlocks();
         $params['params'] = $this->diehard()->getDynamicParams();
@@ -41,7 +41,7 @@ class Cm_Diehard_Block_Beforebodyend extends Mage_Core_Block_Template
      */
     public function getLoadAjaxUrl()
     {
-        $params = array();
+        $params = [];
         if (Mage::app()->getStore()->isCurrentlySecure()) {
             $params['_secure'] = TRUE;
         }
@@ -53,7 +53,7 @@ class Cm_Diehard_Block_Beforebodyend extends Mage_Core_Block_Template
      */
     public function getLoadEsiUrl()
     {
-        $params = array();
+        $params = [];
         if (Mage::app()->getStore()->isCurrentlySecure()) {
             $params['_secure'] = TRUE;
         }

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -22,17 +22,17 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
 
     protected $_lifetime = FALSE;
 
-    protected $_tags = array();
+    protected $_tags = [];
 
-    protected $_blocks = array();
+    protected $_blocks = [];
 
-    protected $_defaultIgnoredBlocks = array();
+    protected $_defaultIgnoredBlocks = [];
 
-    protected $_addedIgnoredBlocks = array();
+    protected $_addedIgnoredBlocks = [];
 
-    protected $_removedIgnoredBlocks = array();
+    protected $_removedIgnoredBlocks = [];
 
-    protected $_params = array();
+    protected $_params = [];
 
     /**
      * @return bool
@@ -76,7 +76,7 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFullActionName()
     {
@@ -220,7 +220,7 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $ignoredBlocks = Mage::getSingleton('core/cookie')->get(self::COOKIE_IGNORED_BLOCKS);
         if ($ignoredBlocks == '-') {
-          return array();
+          return [];
         }
         return ($ignoredBlocks === FALSE ? NULL : explode(',', $ignoredBlocks));
     }
@@ -278,7 +278,7 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
         $ignored = array_diff($ignored, $this->_removedIgnoredBlocks);
         $blocks = array_diff($blocks, $ignored);
 
-        $observedBlocks = array();
+        $observedBlocks = [];
         foreach($this->getDynamicBlocks() as $htmlId => $nameInLayout) {
             if (in_array($nameInLayout, $blocks)) {
                 $observedBlocks[$htmlId] = $nameInLayout;
@@ -351,7 +351,9 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getBackend()
     {
-        return Mage::getSingleton($this->getBackendModel());
+        /** @var Cm_Diehard_Model_Backend_Abstract $backendModel */
+        $backendModel = Mage::getSingleton($this->getBackendModel());
+        return $backendModel;
     }
 
     /**
@@ -367,7 +369,7 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function useAjax()
     {
-        return $this->getBackend()->useAjax() && $this->getJsLib();
+        return $this->getBackend()->useAjax() && $this->getJslib();
     }
 
     /**
@@ -375,7 +377,7 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function useEsi()
     {
-        return $this->getBackend()->useEsi() && $this->getJsLib();
+        return $this->getBackend()->useEsi() && $this->getJslib();
     }
 
     /**
@@ -383,7 +385,7 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function useJs()
     {
-        return $this->getBackend()->useJs() && $this->getJsLib();
+        return $this->getBackend()->useJs() && $this->getJslib();
     }
 
     /**
@@ -425,22 +427,22 @@ class Cm_Diehard_Helper_Data extends Mage_Core_Helper_Abstract
             }
             if ( ! $cookieConfig) {
                 $this->initApp();
-                $cookie = Mage::getSingleton('core/cookie'); /* @var $cookie Mage_Core_Model_Cookie */
-                $cookieConfig = array(
+                $cookie = Mage::getSingleton('core/cookie'); /** @var Mage_Core_Model_Cookie $cookie */
+                $cookieConfig = [
                     'period' => $cookie->getLifetime(),
                     'path'   => $cookie->getPath(),
                     'domain' => $cookie->getDomain(),
                     'admin'  => Mage::app()->getStore()->isAdmin(),
                     'httponly' => $cookie->getHttponly(),
-                );
-                Mage::app()->saveCache(serialize($cookieConfig), $cacheKey, array(Mage_Core_Model_Config::CACHE_TAG));
+                ];
+                Mage::app()->saveCache(serialize($cookieConfig), $cacheKey, [Mage_Core_Model_Config::CACHE_TAG]);
             }
             extract($cookieConfig);
-            /* @var $period int */
-            /* @var $path string */
-            /* @var $domain string */
-            /* @var $admin bool */
-            /* @var $httponly bool */
+            /** @var int $period */
+            /** @var string $path */
+            /** @var string $domain */
+            /** @var bool $admin */
+            /** @var bool $httponly */
             $expire = $period == 0 ? 0 : time() + $period;
             $secure = $admin && isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on';
             setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);

--- a/code/Model/Backend/Abstract.php
+++ b/code/Model/Backend/Abstract.php
@@ -69,7 +69,7 @@ abstract class Cm_Diehard_Model_Backend_Abstract
     public function getCacheKey()
     {
         if ( ! self::$_cacheKey) {
-            self::$_cacheKey = strtoupper(implode('_', array(
+            self::$_cacheKey = strtoupper(implode('_', [
                 'DIEHARD',
                 $this->_name,
                 // Mage::app()->getStore()->getId(), // Can't be used before init
@@ -78,7 +78,7 @@ abstract class Cm_Diehard_Model_Backend_Abstract
                 Mage::app()->getRequest()->getRequestUri(),
                 Mage::app()->getRequest()->getCookie(Cm_Diehard_Helper_Data::COOKIE_CACHE_KEY_DATA, '')
                 // Design?
-            )));
+            ]));
         }
         return self::$_cacheKey;
     }

--- a/code/Model/Backend/Local.php
+++ b/code/Model/Backend/Local.php
@@ -52,9 +52,9 @@ class Cm_Diehard_Model_Backend_Local extends Cm_Diehard_Model_Backend_Abstract
     protected static $_useCachedResponse = NULL;
     protected $_cache;
 
-    protected $_defaultBackendOptions = array(
+    protected $_defaultBackendOptions = [
         'file_name_prefix'          => 'diehard',
-    );
+    ];
 
     /**
      * Clear all cached pages
@@ -140,7 +140,7 @@ class Cm_Diehard_Model_Backend_Local extends Cm_Diehard_Model_Backend_Abstract
      * This method is called by Mage_Core_Model_Cache->processRequest()
      *
      * @param  string|bool $content
-     * @return bool
+     * @return string|bool
      */
     public function extractContent($content)
     {
@@ -161,7 +161,7 @@ class Cm_Diehard_Model_Backend_Local extends Cm_Diehard_Model_Backend_Abstract
             if (0 /* TODO optional events_enabled feature */) {
                 Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_FRONTEND, Mage_Core_Model_App_Area::PART_CONFIG);
                 Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_FRONTEND, Mage_Core_Model_App_Area::PART_EVENTS);
-                Mage::dispatchEvent('diehard_use_cached_response', array('backend' => $this));
+                Mage::dispatchEvent('diehard_use_cached_response', ['backend' => $this]);
             }
 
             if ($this->getUseCachedResponse()) {
@@ -200,7 +200,7 @@ class Cm_Diehard_Model_Backend_Local extends Cm_Diehard_Model_Backend_Abstract
 
                             // Flush cached portion (start session first)
                             $this->helper()->initApp();
-                            Mage::getSingleton('core/session', array('name' => $params['session_name']));
+                            Mage::getSingleton('core/session', ['name' => $params['session_name']]);
                             Mage::app()->getResponse()->setBody($first)->sendResponse();
                             if (ob_get_level()) {
                                 ob_flush();
@@ -318,7 +318,7 @@ class Cm_Diehard_Model_Backend_Local extends Cm_Diehard_Model_Backend_Abstract
                 Mage::app()->getConfig()->createDirIfNotExists($this->_defaultBackendOptions['cache_dir']);
                 $options = $cacheConfig->asArray();
                 if ( ! isset($options['backend_options'])) {
-                    $options['backend_options'] = array();
+                    $options['backend_options'] = [];
                 }
                 $options['backend_options'] = array_merge($this->_defaultBackendOptions, $options['backend_options']);
                 $this->_cache = Mage::getModel('core/cache', $options);

--- a/code/Model/Backend/Proxy.php
+++ b/code/Model/Backend/Proxy.php
@@ -25,7 +25,7 @@ class Cm_Diehard_Model_Backend_Proxy extends Cm_Diehard_Model_Backend_Abstract
      */
     public function flush()
     {
-        $this->_cleanCache(array(self::CACHE_TAG));
+        $this->_cleanCache([self::CACHE_TAG]);
     }
 
     /**
@@ -74,7 +74,7 @@ class Cm_Diehard_Model_Backend_Proxy extends Cm_Diehard_Model_Backend_Abstract
      */
     protected function _getCacheTags($tags)
     {
-        $saveTags = array();
+        $saveTags = [];
         foreach($tags as $tag) {
             $saveTags[] = self::PREFIX_TAG.strtoupper($tag);
         }
@@ -96,7 +96,7 @@ class Cm_Diehard_Model_Backend_Proxy extends Cm_Diehard_Model_Backend_Abstract
               $tags[$key] = $prefix.$value;
             }
             $ids = Mage::app()->getCache()->getIdsMatchingAnyTags($tags);
-            $urls = array();
+            $urls = [];
             foreach($ids as $id) {
               if ($url = Mage::app()->loadCache($id)) {
                 $urls[] = $url;

--- a/code/Model/Backend/Revalidating.php
+++ b/code/Model/Backend/Revalidating.php
@@ -123,6 +123,7 @@ class Cm_Diehard_Model_Backend_Revalidating extends Cm_Diehard_Model_Backend_Abs
     public function extractContent($content)
     {
         $hit = FALSE;
+        $fullActionName = null;
 
         // Use ETags if given
         if (

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -46,8 +46,8 @@ class Cm_Diehard_Model_Observer
     public function controllerActionLayoutLoadBefore(Varien_Event_Observer $observer)
     {
         if ($this->helper()->isEnabled() && $this->helper()->getLifetime()) {
-            $layout = $observer->getEvent()->getLayout(); /* @var $layout Mage_Core_Model_Layout */
-            $handles = array();
+            $layout = $observer->getEvent()->getLayout(); /** @var Mage_Core_Model_Layout $layout */
+            $handles = [];
             foreach ($layout->getUpdate()->getHandles() as $handle) {
                 $handles[] = $handle;
                 if (preg_match('/^[a-z_]+$/', $handle)) {
@@ -66,14 +66,14 @@ class Cm_Diehard_Model_Observer
     public function httpResponseSendBefore(Varien_Event_Observer $observer)
     {
         if ($this->helper()->isEnabled() && ! Mage::registry('diehard_cache_hit')) {
-            $response = $observer->getResponse(); /* @var $response Mage_Core_Controller_Response_Http */
+            $response = $observer->getResponse(); /** @var Mage_Core_Controller_Response_Http $response */
             $fullActionName = $this->helper()->getFullActionName();
 
-            Mage::dispatchEvent('diehard_response_send_before_'.strtolower($this->helper()->getBackend()->getName()), array(
+            Mage::dispatchEvent('diehard_response_send_before_'.strtolower($this->helper()->getBackend()->getName()), [
               'response' => $response,
               'full_action_name' => $fullActionName,
               'lifetime' => $this->helper()->getLifetime(),
-            ));
+            ]);
 
             // Update ignored blocks cookie
             $ignored = $this->helper()->getIgnoredBlocks();

--- a/code/Model/System/Config/Backend.php
+++ b/code/Model/System/Config/Backend.php
@@ -9,15 +9,15 @@ class Cm_Diehard_Model_System_Config_Backend
 
     public function toOptionArray()
     {
-        $options = array(array(
+        $options = [[
           'label' => Mage::helper('diehard')->__('Disabled'),
           'value' => '',
-        ));
+        ]];
         foreach(Mage::getConfig()->getNode('global/diehard/backends')->children() as $backend) {
-            $options[] = array(
+            $options[] = [
                 'label' => Mage::helper('diehard')->__((string) $backend->label),
                 'value' => $backend->getName()
-            );
+            ];
         }
         return $options;
     }

--- a/code/Model/System/Config/Cachecontrol.php
+++ b/code/Model/System/Config/Cachecontrol.php
@@ -8,24 +8,24 @@ class Cm_Diehard_Model_System_Config_Cachecontrol {
 
     public function toOptionArray()
     {
-        return array(
-            array(
+        return [
+            [
                 'label' => Mage::helper('diehard')->__('Proxy cache only'),
                 'value' => 'public, no-cache="set-cookie", s-maxage=%d',
-            ),
-            array(
+            ],
+            [
                 'label' => Mage::helper('diehard')->__('Proxy cache only, must-revalidate'),
                 'value' => 'public, no-cache="set-cookie", must-revalidate, s-maxage=%d',
-            ),
-            array(
+            ],
+            [
                 'label' => Mage::helper('diehard')->__('Client-side cache allowed'),
                 'value' => 'private, max-age=%d',
-            ),
-            array(
+            ],
+            [
                 'label' => Mage::helper('diehard')->__('Client-side cache allowed, must-revalidate'),
                 'value' => 'private, must-revalidate, max-age=%d',
-            ),
-        );
+            ],
+        ];
     }
 
 }

--- a/code/Model/System/Config/Injection.php
+++ b/code/Model/System/Config/Injection.php
@@ -8,20 +8,20 @@ class Cm_Diehard_Model_System_Config_Injection {
 
     public function toOptionArray()
     {
-        return array(
-            array(
+        return [
+            [
                 'label' => Mage::helper('diehard')->__('Javascript'),
                 'value' => 'js',
-            ),
-            array(
+            ],
+            [
                 'label' => Mage::helper('diehard')->__('Ajax'),
                 'value' => 'ajax',
-            ),
-            array(
+            ],
+            [
                 'label' => Mage::helper('diehard')->__('ESI'),
                 'value' => 'esi',
-            ),
-        );
+            ],
+        ];
     }
 
 }

--- a/code/Model/System/Config/Jslib.php
+++ b/code/Model/System/Config/Jslib.php
@@ -8,9 +8,9 @@ class Cm_Diehard_Model_System_Config_Jslib {
 
     public function toOptionArray()
     {
-        $options = array();
+        $options = [];
         foreach( Mage::getConfig()->getNode('global/diehard/jslibs')->children() as $data) {
-            $options[] = array('value' => (string) $data->path, 'label' => (string) $data->label);
+            $options[] = ['value' => (string) $data->path, 'label' => (string) $data->label];
         }
         return $options;
     }

--- a/code/controllers/LoadController.php
+++ b/code/controllers/LoadController.php
@@ -17,14 +17,14 @@ class Cm_Diehard_LoadController extends Mage_Core_Controller_Front_Action
     protected function _getResponseObject()
     {
         // Disable caching mode temporarily
-        $helper = Mage::helper('diehard'); /* @var $helper Cm_Diehard_Helper_Data */
+        $helper = Mage::helper('diehard'); /** @var Cm_Diehard_Helper_Data $helper */
         $oldLifetime = $helper->getLifetime();
         $helper->setLifetime(FALSE);
 
-        $response = array(
-            'blocks' => array(),
-            'ignoreBlocks' => array(),
-        );
+        $response = [
+            'blocks' => [],
+            'ignoreBlocks' => [],
+        ];
 
         // Translate JSON params to top-level params
         if ($params = $this->getRequest()->getParam('json')) {
@@ -38,12 +38,13 @@ class Cm_Diehard_LoadController extends Mage_Core_Controller_Front_Action
         }
 
         // Add handles to layout
-        $handles = array(
+        $handles = [
             'DIEHARD_default',  // DEPRECATED!!
             'DIEHARD_'.$this->getRequest()->getParam('full_action_name'), // DEPRECATED!!
             'DIEHARD_DYNAMIC_default',
             'DIEHARD_DYNAMIC_'.$this->getRequest()->getParam('full_action_name')
-        );
+        ];
+
         $this->loadLayout($handles);
         $layout = $this->getLayout();
 
@@ -51,7 +52,7 @@ class Cm_Diehard_LoadController extends Mage_Core_Controller_Front_Action
         
         // Render all blocks contents
         if ($this->getRequest()->getParam('all_blocks')) {
-            foreach ($this->getLayout()->getAllBlocks() as $block) { /* @var $block Mage_Core_Block_Abstract */
+            foreach ($this->getLayout()->getAllBlocks() as $block) { /** @var Mage_Core_Block_Abstract $block */
             if (! in_array($block->getNameInLayout(), $ignoredBlocks)) {
                     $selector = $block->getDiehardSelector();
                     $response['blocks'][$selector] = $block->toHtml();
@@ -61,7 +62,7 @@ class Cm_Diehard_LoadController extends Mage_Core_Controller_Front_Action
 
         // When using Ajax the client can specify a subset of available blocks
         else {
-            $requestedBlockNames = $this->getRequest()->getParam('blocks', array());
+            $requestedBlockNames = $this->getRequest()->getParam('blocks', []);
             foreach ($requestedBlockNames as $selector => $requestedBlockName) {
                 if (! in_array($requestedBlockName, $ignoredBlocks)) {
                     $tmpBlock = $layout->getBlock($requestedBlockName);

--- a/frontend/template/beforebodyend.phtml
+++ b/frontend/template/beforebodyend.phtml
@@ -1,4 +1,4 @@
-<?php /* @var $this Cm_Diehard_Block_Beforebodyend */ ?>
+<?php /** @var Cm_Diehard_Block_Beforebodyend $this */ ?>
 <?php if ( ! $this->diehard() || ! $this->diehard()->getDynamicBlocks()) return; ?>
 <?php if ($this->diehard()->useAjax()): ?>
 <script type="text/javascript">


### PR DESCRIPTION
This update modernizes PHP code across module files under `code/` and synchronizes `Mage/Core` files with the current OpenMage core, improving code correctness, type safety, and making future upstream comparisons easier.

**Code style**

* Replaced legacy `array()` syntax with short `[]` array syntax
* Converted inline `/* @var */` annotations to proper `/** @var */` PHPDoc format

**Bug fixes**

* Fixed incorrect method call `getJsLib()` → `getJslib()` in `Helper/Data.php` (`useAjax()`, `useEsi()`, `useJs()`)

**Type annotations**

* Corrected `@return` annotations:

  * `getFullActionName()` → `string|null`
  * `extractContent()` in `Backend/Local.php` → `string|bool`
* Added missing `@var Cm_Diehard_Model_Backend_Abstract` annotation for the `getBackend()` return value

**Code safety**

* Initialized `$fullActionName = null` in `Backend/Revalidating.php` to avoid a potential undefined variable